### PR TITLE
Agrega instrucción para copiar archivos al contenedor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,3 @@
 FROM islasgeci/base
 RUN Rscript -e "install.packages(c('survey'), repos='http://cran.rstudio.com')"
+COPY . .


### PR DESCRIPTION
Agrega la instrucción en el Dockerfile para que se vinculen los archivos del directorio del repositorio con el contenedor